### PR TITLE
Add example for turning unamed prepared queries on

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,17 @@ queries after the transactions closes. To force unnamed prepared queries:
 Postgrex.start_link(prepare: :unnamed)
 ```
 
+This option can be set via the config for your Ecto Repo:
+
+```elixir
+# Configure your database
+config :myapp, MyApp.Repo,
+  priv: "priv/repo/myapp",
+  adapter: Ecto.Adapters.Postgres,
+  ...
+  prepare: :unnamed
+```
+
 ## Contributing
 
 To contribute you need to compile Postgrex from source and test it:


### PR DESCRIPTION
  Added an example for configuring prepared statements via ecto config. Had to do this recently (today) and was quite confused on how I could do this without having to pass the start_link param manually. 

Cheers :)